### PR TITLE
Fixed an issue with Peek and Find Definition on Windows for VS Code 1.13

### DIFF
--- a/src/lib/apexDefinitionProvider.ts
+++ b/src/lib/apexDefinitionProvider.ts
@@ -27,7 +27,7 @@ export class ApexDefinitionProvider implements vscode.DefinitionProvider{
                     if (obj.filePath.indexOf(this.toolingService.tempFolder) >= 0){
                         obj.filePath = document.fileName;
                     }
-                    let def = new vscode.Location(vscode.Uri.parse(path.normalize('file:' + obj.filePath)), new vscode.Range(obj.line-1, obj.column,obj.line,obj.column));
+                    let def = new vscode.Location(vscode.Uri.file(path.normalize(obj.filePath)), new vscode.Range(obj.line-1, obj.column,obj.line,obj.column));
                     resolve(def);
                 }catch(e) {
                     reject(e)


### PR DESCRIPTION
@ChuckJonas - entered a pull request for https://github.com/ChuckJonas/vscode-apex-autocomplete/issues/21. Should work like a charm again.