### PR TITLE
Fixed windows issue were user profiles contains spaces

### DIFF
--- a/src/lib/apexToolingService.ts
+++ b/src/lib/apexToolingService.ts
@@ -32,7 +32,7 @@ export class ApexToolingService{
     }
 
     public startService(){
-        let cmd = `java -Dfile.encoding=UTF-8  -jar ${this.jarPath} --action=serverStart --port=${this.port} --timeoutSec=1800`;
+        let cmd = `java -Dfile.encoding=UTF-8  -jar "${this.jarPath}" --action=serverStart --port=${this.port} --timeoutSec=1800`;
 
         this.outputChannel.appendLine(`Starting Language Server. CMD: ${cmd}`);
 


### PR DESCRIPTION
In case the user profile path on windows contains spaces the server does not start as the path to the server's jar file's location is not encapsulate in quotes. 